### PR TITLE
SITL Logging Feature and Misc Bug Fixes

### DIFF
--- a/djinn
+++ b/djinn
@@ -41,7 +41,7 @@ then
 	then
 		read -p "Enter email address for github: " email
 		read -p "Enter username for dockerhub: " name
-		echo "VERSION=0.0.4" >> $config_file
+		echo "VERSION=0.0.8" >> $config_file
 		echo "ROS_VERSION=\"humble\"" >> $config_file
 		echo "userEmail="$email >> $config_file 
 		echo "userName="$name >> $config_file 
@@ -68,32 +68,32 @@ then
 			echo "============ BUILDING Image ============="
 			if [[ "$3" == "nrt" ]]
 			then
-				# echo "============ BUILDING Base Image ============="
-				# image="$userName/nrt:base"
-				# filepath="$NRT_WS/docker/base/"
-				# build_image $platform $image $filepath
-				# echo "============ BUILDING ROS Image ============="
-				# image="$userName/nrt:ros"
-				# filepath="$NRT_WS/docker/base/ros"
-				# platform="linux/amd64,linux/arm64"
-				# build_image $platform $image $filepath 
-				# echo "============ BUILDING NRT Pangolin Image ============="
-				# image="$userName/nrt:pangolin"
-				# filepath="$NRT_WS/docker/nrt/pangolin"
-				# platform="linux/amd64,linux/arm64"
-				# build_image $platform $image $filepath 
+				echo "============ BUILDING Base Image ============="
+				image="$userName/nrt:base"
+				filepath="$NRT_WS/docker/base/"
+				build_image $platform $image $filepath
+				echo "============ BUILDING ROS Image ============="
+				image="$userName/nrt:ros"
+				filepath="$NRT_WS/docker/base/ros"
+				platform="linux/amd64,linux/arm64"
+				build_image $platform $image $filepath 
+				echo "============ BUILDING NRT Pangolin Image ============="
+				image="$userName/nrt:pangolin"
+				filepath="$NRT_WS/docker/nrt/pangolin"
+				platform="linux/amd64,linux/arm64"
+				build_image $platform $image $filepath 
 				echo "============ BUILDING NRT Camera Image ============="
 				image="$userName/nrt:camera"
 				filepath="$NRT_WS/docker/nrt/camera"
 				platform="linux/amd64,linux/arm64"
 				container_name="nrt_container"
-				# build_image $platform $image $filepath 
+				build_image $platform $image $filepath 
 				echo "============ BUILDING NRT VERSION:$VERSION Image ============="
+				setup_airsim_ros_pkgs_for_docker_build "ardupilot"
 				image="$userName/nrt:$VERSION"
 				filepath="$NRT_WS/docker/nrt/ardupilot"
 				platform="linux/amd64,linux/arm64"
 				container_name="nrt_container"
-				setup_airsim_ros_pkgs_for_docker_build "ardupilot"
 				build_image $platform $image $filepath 
 				iexec init_container "rm -rf /ws/docker/nrt/ardupilot/airsim_ws"
 				docker stop init_container
@@ -242,7 +242,7 @@ then
 		# gnome-terminal --title "AirSim ROS bridge" -- bash -c "$NRT_WS/envs/scripts/run_airsim_ros_pkgs.sh"
 		# sleep 3
 		# gnome-terminal --title "SITL Bridge" -- bash -c "$NRT_WS/envs/scripts/run_sitl_ardupilot_bridge.sh"
-		gnome-terminal --title "SITL Bridge" -- bash -c "$NRT_WS/envs/scripts/run_ardupilot_airsim_ros_sitl.sh;"
+		gnome-terminal --title "SITL Bridge" -- bash -c "$NRT_WS/envs/scripts/run_ardupilot_airsim_ros_sitl.sh"
 		# source $NRT_WS/envs/scripts/run_sitl_ardupilot_bridge.sh
 		gnome-terminal --title "QGroundControl" -- bash -c "$NRT_WS/ext/QGroundControl.AppImage"
 		# stop_sitl_container

--- a/docker/ardupilot/Dockerfile
+++ b/docker/ardupilot/Dockerfile
@@ -41,5 +41,7 @@ RUN vim -c PluginInstall -c qall && ls && \
 	python3 ./install.py --force-sudo --clang-completer && \
 	cp /home/${USER_NAME}/.vim/bundle/youcompleteme/third_party/ycmd/.ycm_extra_conf.py  /home/${USER_NAME}/.vim/
 
+RUN apt-get install -y ros-humble-ffmpeg-image-transport
+
 ENTRYPOINT ["/ardupilot_entrypoint.sh"]
 CMD ["bash"]

--- a/docker/base/ros/Dockerfile
+++ b/docker/base/ros/Dockerfile
@@ -1,8 +1,9 @@
 FROM shandilya1998/nrt:base
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl && \
-	curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg && \
-	echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+	export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') && \
+	curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $UBUNTU_CODENAME)_all.deb" && \
+	apt install /tmp/ros2-apt-source.deb
 
 # install ros2 packages
 RUN apt-get update && apt-get install -y --no-install-recommends ros-humble-ros-core=0.10.0-1* && \

--- a/docker/nrt/ardupilot/Dockerfile
+++ b/docker/nrt/ardupilot/Dockerfile
@@ -47,5 +47,7 @@ RUN apt-get install wget && chmod +x build.sh && ./build.sh
 
 WORKDIR /ws
 
+RUN apt-get update && apt-get install -y ros-humble-ffmpeg-image-transport
+
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["bash"]

--- a/docker/nrt/camera/Dockerfile
+++ b/docker/nrt/camera/Dockerfile
@@ -36,7 +36,7 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then \
 		meson setup build --buildtype=release -Dpipelines=rpi/vc4,rpi/pisp -Dipas=rpi/vc4,rpi/pisp -Dv4l2=true -Dgstreamer=enabled -Dtest=false -Dlc-compliance=disabled -Dcam=disabled -Dqcam=disabled -Ddocumentation=disabled -Dpycamera=enabled && \
 		ninja -C build install; \
 	elif [ "$(uname -m)" = "x86_64" ]; then \
-		git clone https://git.libcamera.org/libcamera/libcamera.git && \
+		git clone https://github.com/libcamera-org/libcamera.git && \
 		cd libcamera && \
 		meson setup build --buildtype=release -Dv4l2=true -Dgstreamer=enabled -Dtest=false && \
 		ninja -C build install; \

--- a/docker/nrt/sitl/Dockerfile
+++ b/docker/nrt/sitl/Dockerfile
@@ -62,7 +62,7 @@ RUN vim -c PluginInstall -c qall && ls && \
 WORKDIR /airsim_ws
 ADD ./airsim_ws /airsim_ws
 COPY ./build_airsim.sh /airsim_ws/build.sh
-RUN apt-get install -y zip unzip ros-humble-vision-opencv ros-humble-cv-bridge && chmod +x build.sh && ./build.sh
+RUN apt-get install -y zip unzip ros-humble-vision-opencv ros-humble-cv-bridge ros-humble-ffmpeg-image-transport && chmod +x build.sh && ./build.sh
 
 ENTRYPOINT ["/ros_entrypoint.sh"]
 CMD ["bash"]

--- a/docker/nrt/sitl/ros2.repos
+++ b/docker/nrt/sitl/ros2.repos
@@ -2,7 +2,7 @@ repositories:
   ardupilot:
     type: git
     url: https://github.com/ArduPilot/ardupilot.git
-    version: master
+    version: 229bcaacd5404bbdc5a4d0ae9a74a46ed5e12db9
   micro_ros_agent:
     type: git
     url: https://github.com/micro-ROS/micro-ROS-Agent.git


### PR DESCRIPTION
Problem
=======
1. Need to add `ros-humble-ffmpeg-image-transport` to nrt:0.0.8
2. Error in rebuilding nrt:ros due to expired permissions
3. Unable to access https://git.libcamera.org/libcamera/libcamera.git
4. Error in building ArduPilot ROS2 SITL due to recent changes in ardupilot repository

Solution
========
1. Added installation of `ros-humble-ffmpeg-image-transport` in `docker/ardupilot/Dockerfile`, `docker/nrt/ardupilot/Dockerfile` and `docker/nrt/sitl/Dockerfile`
2. Updated `docker/nrt/ros/Dockerfile` to use latest certificates for package updates
3. Updated link to libcamera repo to https://github.com/libcamera-org/libcamera.git
4. Updated `docker/nrt/sitl/ros2.repos` to use last working commit of ArduPilot

Note
====
1. Updated default image for new installations to 0.0.8
2. Restored `djinn init docker nrt` to original full build configuration